### PR TITLE
Remove all number formatting

### DIFF
--- a/src/main/c/app/app.c
+++ b/src/main/c/app/app.c
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-#include <locale.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -44,7 +43,7 @@ static void compute_primes(bool* integers, int range) {
 }
 
 static void print_primes(bool* integers, int range) {
-  printf("Prime numbers in range 0-%'d inclusive:\n", range);
+  printf("Prime numbers in range 0-%d inclusive:\n", range);
   for (int p = 2; p <= range; ++p) {
     if (integers[p]) {
       if (range <= 1000 || range - p <= 1000) {
@@ -69,7 +68,6 @@ static float get_elapsed(struct timeval* start, struct timeval* end) {
 }
 
 int main(int argc, char* argv[]) {
-  setlocale(LC_NUMERIC, "");
   printf("Sieve of Eratosthenes: Find all prime numbers in a given range\n");
 
   int range = argc > 1 ? atoi(argv[1]) : read_range();
@@ -83,7 +81,7 @@ int main(int argc, char* argv[]) {
   print_primes(integers, range);
   int count = get_count(integers, range);
   float elapsed = get_elapsed(&start_time, &end_time);
-  printf("\nFound %'d prime(s) in %'d integers in %'.0f microseconds\n\n",
+  printf("\nFound %d prime(s) in %d integers in %.0f microseconds\n\n",
       count, range, elapsed);
 
   return 0;

--- a/src/main/c/app2/sieve.c
+++ b/src/main/c/app2/sieve.c
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -109,8 +108,7 @@ void sieve_compute_primes(sieve* self) {
 }
 
 void sieve_print_primes(const sieve* self) {
-  setlocale(LC_NUMERIC, "");
-  printf("Prime numbers in range 0-%'d inclusive:\n", self->range);
+  printf("Prime numbers in range 0-%d inclusive:\n", self->range);
   int half = self->count / 2;
   for (int n = 0; n < self->count; ++n) {
     int p = self->primes[n];
@@ -124,7 +122,7 @@ void sieve_print_primes(const sieve* self) {
       printf("%d ", p);
     }
   }
-  printf("\nFound %'d prime(s) in %'d integers in %'.0f microseconds\n\n",
+  printf("\nFound %d prime(s) in %d integers in %.0f microseconds\n\n",
       sieve_get_count(self), sieve_get_range(self), sieve_get_elapsed(self));
 }
 

--- a/src/main/c/sieve/csieve.c
+++ b/src/main/c/sieve/csieve.c
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -97,8 +96,7 @@ static void compute_primes(csieve* self) {
 }
 
 static void print_primes(const csieve* self) {
-  setlocale(LC_NUMERIC, "");
-  printf("Prime numbers in range 0-%'d inclusive:\n", self->range);
+  printf("Prime numbers in range 0-%d inclusive:\n", self->range);
 
   int half = self->count / 2;
   for (int n = 0; n < self->count; ++n) {
@@ -114,7 +112,7 @@ static void print_primes(const csieve* self) {
     }
   }
   
-  printf("\nFound %'d prime(s) in %'d integers in %'.0f microseconds\n\n",
+  printf("\nFound %d prime(s) in %d integers in %.0f microseconds\n\n",
       self->get_count(self), self->get_range(self), self->get_elapsed(self));
 }
 

--- a/src/main/cpp/app/app.cpp
+++ b/src/main/cpp/app/app.cpp
@@ -59,7 +59,6 @@ void App::compute_primes() {
 }
 
 void App::print_primes() {
-  std::cout.imbue(std::locale(""));
   std::cout << "Prime numbers in range 0-" << this->range << " inclusive:" << std::endl;
   for (int p = 0; p <= this->range; ++p) {
     if (this->primes[p]) {

--- a/src/main/cpp/app2/sieve.cpp
+++ b/src/main/cpp/app2/sieve.cpp
@@ -79,7 +79,6 @@ void Sieve::compute_primes() {
 }
 
 void Sieve::print_primes() const {
-  std::cout.imbue(std::locale(""));
   std::cout << "Prime numbers in range 0-" << this->range << " inclusive:" << std::endl;
   int half = this->primes.size() / 2;
   for (size_t n = 0; n < this->primes.size(); n++) {

--- a/src/main/java/com/shaygordon/primes/App.java
+++ b/src/main/java/com/shaygordon/primes/App.java
@@ -16,7 +16,6 @@
 package com.shaygordon.primes;
 
 import java.io.InputStreamReader;
-import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.InputMismatchException;
 import java.util.Scanner;
@@ -26,8 +25,6 @@ import java.util.Scanner;
  * Sieve of Eratosthenes algorithm.
  */
 public class App {
-  private static DecimalFormat formatter = new DecimalFormat("#,###");
-
   private static int getRange() {
     int range = 0;
     System.out.print("Enter highest integer to test for primeness: ");
@@ -67,8 +64,7 @@ public class App {
 
   private static void printPrimes(boolean[] prime) {
     int range = prime.length - 1;
-    System.out.println(
-        String.format("Prime numbers up to %s:", formatter.format(range)));
+    System.out.println(String.format("Prime numbers in range 0-%d:", range));
     for (int p = 2; p <= range; p++) {
       if (prime[p]) {
         if (range <= 1000 || range - p <= 1000) {
@@ -94,7 +90,8 @@ public class App {
     double duration = (System.nanoTime() - start) / 1_000.;
     printPrimes(prime);
     int count = getCount(prime);
-    System.out.println(String.format("\nFound %s prime(s) in %s integers in %s microseconds\n",
-        formatter.format(count), formatter.format(range), formatter.format(duration)));
+    System.out.println(
+        String.format("\nFound %d prime(s) in %d integers in %.0f microseconds\n",
+            count, range, duration));
   }
 }

--- a/src/main/java/com/shaygordon/primes/Sieve.java
+++ b/src/main/java/com/shaygordon/primes/Sieve.java
@@ -15,7 +15,6 @@
  */
 package com.shaygordon.primes;
 
-import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -28,7 +27,6 @@ public class Sieve {
   // defines the number of prines to display around an ellipsis that is used
   // when large numbers of primes are equested
   private static int MAX_HALF = 10;
-  private static DecimalFormat FMT = new DecimalFormat("#,###");
 
   private int range;
   private boolean[] integers;
@@ -38,8 +36,6 @@ public class Sieve {
   /***
    * Private functions
    */
-  private static String format(Number value) { return FMT.format(value); }
-
   private static boolean[] createIntegers(int range) {
     boolean[] integers = new boolean[range + 1];
     Arrays.fill(integers, true);
@@ -81,7 +77,7 @@ public class Sieve {
   }
 
   public void printPrimes() {
-    System.out.println(String.format("Prime numbers up to %s:", format(range)));
+    System.out.println(String.format("Prime numbers in range 0-%d:", range));
     StringBuilder sb = new StringBuilder();
     int half = this.primes.size() / 2;
     for (int n = 0; n < this.primes.size(); n++) {
@@ -97,8 +93,9 @@ public class Sieve {
       }
     }
     System.out.println(sb);
-    System.out.println(String.format("Found %s prime(s) in %s integers in %s microseconds\n",
-        format(this.primes.size()), format(this.range), format(this.getElapsed())));
+    System.out.println(
+        String.format("Found %d prime(s) in %d integers in %.0f microseconds\n",
+            this.primes.size(), this.range, this.getElapsed()));
   }
 
   public List<Integer> getPrimes() {

--- a/src/main/js/app.js
+++ b/src/main/js/app.js
@@ -23,9 +23,6 @@ const { _, performance } = require("perf_hooks");
  * Sieve of Eratosthenes algorithm.
  */
 
-/** Lambda that simplifies printing numbers with thousands separators. */
-const numToStr = n => { return Number(n).toLocaleString() };
-
 function main(range) {
   let integers = new Array(range + 1);
   integers.fill(true);
@@ -36,9 +33,8 @@ function main(range) {
   printPrimes(integers);
   let count = getCount(integers);
   let elapsed = getElapsed(start, end);
-  console.log("\nFound " + numToStr(count) + " prime(s) in "
-    + numToStr(range) + " integers in "
-    + numToStr(elapsed) + " microseconds\n");
+  console.log("\nFound " + count + " prime(s) in " + range + " integers in "
+      + elapsed + " microseconds\n");
 }
 
 function computePrimes(integers) {
@@ -54,8 +50,8 @@ function computePrimes(integers) {
 }
 
 function printPrimes(integers) {
-  console.log("Prime numbers in range 0-"
-      + numToStr(integers.length - 1) + " inclusive:");
+  console.log("Prime numbers in range 0-" + (integers.length - 1)
+      + " inclusive:");
   integers.forEach((val, p) => {
     if (val) {
       if (integers.length <= 1000 || integers.length - p <= 1000) {

--- a/src/main/js/sieve.js
+++ b/src/main/js/sieve.js
@@ -21,9 +21,6 @@ const { _, performance } = require("perf_hooks");
 // when large numbers of primes are requested
 const MAX_HALF = 10;
 
-/** Lambda that simplifies printing numbers with thousands separators. */
-const numToStr = n => { return Number(n).toLocaleString() }
-
 /**
  * Private methods
  */
@@ -71,8 +68,7 @@ class Sieve {
   }
 
   printPrimes() {
-    console.log("Prime numbers in range 0-"
-      + numToStr(this.range) + " inclusive:");
+    console.log("Prime numbers in range 0-" + this.range + " inclusive:");
     const half = Math.floor(this.count / 2);
     this._primes.forEach((p, n) => {
       if (half > MAX_HALF) {
@@ -85,9 +81,8 @@ class Sieve {
         process.stdout.write(p + " ");
       }
     });
-    console.log("\nFound " + numToStr(this.count) + " prime(s) in "
-      + numToStr(this.range) + " integers in "
-      + numToStr(this.elapsed) + " microseconds\n");
+    console.log("\nFound " + this.count + " prime(s) in "
+        + this.range + " integers in " + this.elapsed + " microseconds\n");
   }
 
   get primes() {
@@ -108,4 +103,3 @@ class Sieve {
 }
 
 module.exports = Sieve;
-

--- a/src/main/python/app.py
+++ b/src/main/python/app.py
@@ -37,7 +37,7 @@ def compute_primes(n):
 
 def print_primes(prime):
   n = len(prime)
-  print(f"Prime numbers in range 0-{n - 1:,d} inclusive:")
+  print(f"Prime numbers in range 0-{n - 1:d} inclusive:")
   for p in range(2, n):
     if prime[p]:
       if n <= 1000 or n - p <= 1000:
@@ -58,7 +58,7 @@ def main():
   elapsed = (time.time() - start_time) * 1_000_000.
   print_primes(primes)
   count = sum(primes) - 2
-  print(f"\nFound {count:,d} prime(s) in {range:,d} integers in {elapsed:,.0f} microseconds\n")
+  print(f"\nFound {count:d} prime(s) in {range:d} integers in {elapsed:.0f} microseconds\n")
   return 0
 
 if __name__ == "__main__":

--- a/src/main/python/sieve.py
+++ b/src/main/python/sieve.py
@@ -62,7 +62,7 @@ class Sieve:
     return self
 
   def print_primes(self):
-    print(f"Prime numbers in range 0-{self.range:,d} inclusive:")
+    print(f"Prime numbers in range 0-{self.range:d} inclusive:")
     half = int(self.get_count() / 2)
     for n, p in enumerate(self.primes):
       if half > Sieve.MAX_HALF:
@@ -72,8 +72,8 @@ class Sieve:
           print(p, end=" ")
       else:
         print(p, end=" ")
-    print(f"\nFound {self.get_count():,d} prime(s) in {self.range:,d} integers in "
-        + f"{self.get_elapsed():,.0f} microseconds\n")
+    print(f"\nFound {self.get_count():d} prime(s) in {self.range:d} integers in "
+        + f"{self.get_elapsed():.0f} microseconds\n")
 
   def get_primes(self):
     return self.primes.copy()


### PR DESCRIPTION
All languages except ISO C provide support for formatting numbers into strings with locale-specific thousands separators. Some C compiler implementations support using an apostrophe in a print format string, e.g., `printf("Range %'d\n", range)`, to indicate that it should be replaced with the locale-specific thousands separator when needed, butthey are not ISO-compliant. Since the aim was to make the output of all sieve algo implementations look the same regardless of the language
used, number formatting has been removed.