### PR TITLE
1.2.0 patches

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,6 +36,9 @@ test-classes/
 # Python-generated files
 __pycache__/
 
+# Go makefile-generated files
+.build.log
+
 # END include .gitignore -----------------------------------------------------
 
 # Git files

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ test-classes/
 
 # Python-generated files
 __pycache__/
+
+# Go makefile-generated files
+.build.log

--- a/README.md
+++ b/README.md
@@ -6,27 +6,29 @@
 
 The primary goals of the project are to:
 
-- demonstrate the similarities and differences between different programming languages by implementing a simple, easy-to-understand algorithm in each of them
-- to provide example implementations of all elements of a DevOps toolchain that supports the delivery, development, and management of software applications throughout the systems development life cycle
+- demonstrate the similarities and differences between several popular programming languages by implementing the same easy-to-understand algorithm in each language
+- provide basic implementations of all elements of a DevOps toolchain that supports the delivery, development, and management of software applications throughout the systems development life cycle
 
-The project is young (weeks old) and akthough it does demonstrate *most* of the DevOps toolchain, it does not currently provide container orchestration (Kubernetes) or CI/CD (Jenkins) but will in the future.
+The project is young (just weeks old) and although it implements *most* of the DevOps toolchain, it does not currently include CI/CD (Jenkins/automated unit testing) or container orchestration (Kubernetes), but will in the future.
 
 ## Features
 
 Each language-specific implementation of the Sieve of Eratosthenes algorithm comes in a minimum of two versions:
-- A naïve version that brute forces the solution. In other words, a hack — difficult to read and to maintain.
-- One or more object-oriented versions that should be more maintainable and use the best practices of the language. In all languages except C, this means extracting a `Sieve` class as a separate component. In the C implementation, it means extracting a opaque structure containing algorithm state, and non-member functions to implement the algorithm and access its results — basically, a rudimentary C++ class with an *explicit* `this` pointer and some data encapsulation.
+1. A *naïve* implementation that brute forces the solution. In other words, a hack job — difficult to read and to maintain.
+2. An *idiomatic* implementation that uses language-specific features to simplify development and maintenance. In this project, that typically means defining a `Sieve` entity as a separate, reusable *object-oriented* (O-O) component, for example, a class, in Python, Java, C++, et al. In C, which is a procedural language with no intrinsic support for encapsulation, it means defining a `struct` that contains state, coupled with non-member functions that access or modify the state and implement the algorithm.
+
+A third version is available for languages that provide a simple way to bind to C library functions. In these language implementations, a single O-O component encapsulates all interactions with the C library, and the C library implements the sieve algorithm. Python's `ctypes` and Go's `cgo` packages are two very good examples of simple but effective C library binding mechanisms.
 
 Project features include:
 
-- The sieve algorithm is implemented in the top five most popular programming languages at the time of writing:
+- The sieve algorithm is implemented in six of the most popular programming languages at the time of writing:
   - C
   - C++
   - Go
   - Java
   - JavaScript
   - Python
-- One **C++**, one **Go** and one **Python** implentation are derived by wrapping a **C** implementation. Similar Java and server-side JavaScript implementations may follow.
+- One **C++**, one **Go** and one **Python** implentation are derived by wrapping a **C** implementation. A Java JNI and nodeserver-side JavaScript (i.e. node.js) implementations may follow.
 - The project uses GNU **make** to:
   - compile and link C, C++ and Go implementations,
   - install reusable libraries, shared objects and header files,
@@ -43,14 +45,14 @@ Project features include:
 
 The project's Sieve of Eratosthenes implementations have been tested on Ubuntu 18.04 LTS, 20.04 LTS and Mac OS 11.2. Containerized versions of the implementations have been tested on Alpine Linux, Fedora and Ubuntu. The following language and tool versions were used:
 
-| Language       | Tool    | Version   |
-| :------------- | ------- | --------- |
-| C              | gcc     | C11       |
-| C++            | g++     | C++17     |
-| Go             | go      | 1.16.3    |
-| Java           | javac   | SE 11 LTS |
-| JavaScript ES5 | node.js | 14.16 LTS |
-| Python         | python3 | 3.8       |
+| Language       | Tool      | Version   |
+| :------------- | --------- | --------- |
+| C              | `gcc`     | C11       |
+| C++            | `g++`     | C++17     |
+| Go             | `go`      | 1.16.3    |
+| Java           | `javac`   | SE 11 LTS |
+| JavaScript ES5 | `node`    | 14.16 LTS |
+| Python         | `python3` | 3.8       |
 
 ## Installation
 

--- a/docker/ubuntu.dockerfile
+++ b/docker/ubuntu.dockerfile
@@ -26,8 +26,7 @@ RUN apt install -y file less tree vim
 
 # install project build & run toolchains
 RUN apt install -y gcc
-RUN apt install -y gccgo-go
-RUN apt install -y golang-go
+RUN apt install -y gccgo
 RUN apt install -y g++
 RUN apt install -y make
 RUN apt install -y maven
@@ -41,6 +40,9 @@ RUN \
   curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh && \
   bash nodesource_setup.sh && \
   apt install -y nodejs
+
+# add go soft link missing from gccgo package
+RUN ln -s /usr/bin/go-10 /usr/bin/go
 
 # copy project source files to image & remove generated files
 WORKDIR /prime

--- a/prime
+++ b/prime
@@ -83,21 +83,28 @@ do
 
   # docker subcommands
   case ${cmd} in
-    up)    docker compose up -d     ;;
-    down)  docker compose down      ;;
-    ps)    docker ps -a             ;;
-    top)   docker compose top       ;;
-    prune) docker system  prune -af ;;
-    build) docker compose build     ;;
+    up)     docker compose up -d     ;;
+    down)   docker compose down      ;;
+    ps)     docker ps -a             ;;
+    top)    docker compose top       ;;
+    prune)  docker system  prune -af ;;
+    build)  docker compose build     ;;
+    bounce)
+      docker compose down      &&
+      docker compose build     &&
+      docker compose up -d
+      ;;
     nuke)
       docker compose down      &&
       docker system  prune -af &&
       make   clean             &&
-      docker compose build
+      docker compose build     &&
+      docker compose up -d
       ;;
 
     alpine|fedora|ubuntu)
       if [ ! -z $@ ]; then
+        # alpine: try to change 'bash' to 'ash' beforte invoking shell
         case $@ in
           clean|all) docker compose exec ${cmd} ./${self} $@ ;;
           *)         docker compose exec ${cmd} $@           ;;

--- a/prime
+++ b/prime
@@ -104,10 +104,12 @@ do
 
     alpine|fedora|ubuntu)
       if [ ! -z $@ ]; then
-        # alpine: try to change 'bash' to 'ash' beforte invoking shell
-        case $@ in
-          clean|all) docker compose exec ${cmd} ./${self} $@ ;;
-          *)         docker compose exec ${cmd} $@           ;;
+        # alpine: bash not installed, use ash instead
+        arg=$@
+        if [ ${cmd} == "alpine" ] && [ ${arg} == "bash" ]; then arg=ash; fi
+        case ${arg} in
+          clean|all) docker compose exec ${cmd} ./${self} ${arg} ;;
+          *)         docker compose exec ${cmd} ${arg}           ;;
         esac
       else
         docker compose exec ${cmd} make
@@ -116,7 +118,7 @@ do
       ;;
 
     *)
-      echo unknown command: \"$cmd\"
+      echo unknown command: \"${cmd}\"
       ;;
   esac
 done

--- a/src/main/go/Makefile
+++ b/src/main/go/Makefile
@@ -25,8 +25,8 @@ $(SUBDIRS):
 	@# run make with no arguments for each subdirectory
 	$(MAKE) --no-print-directory --directory $@
 
-clean scrub test install:
+clean scrub test install version:
 	@$(MAKE) --no-print-directory --directory sieve $@
 	@for subdir in $(SUBDIRS); do $(MAKE) --no-print-directory --directory $$subdir $@; done
 
-.PHONY: sieve $(SUBDIRS) clean test install
+.PHONY: sieve $(SUBDIRS) clean scrub test install version

--- a/src/main/go/Makefile
+++ b/src/main/go/Makefile
@@ -25,7 +25,7 @@ $(SUBDIRS):
 	@# run make with no arguments for each subdirectory
 	$(MAKE) --no-print-directory --directory $@
 
-clean test install:
+clean scrub test install:
 	@$(MAKE) --no-print-directory --directory sieve $@
 	@for subdir in $(SUBDIRS); do $(MAKE) --no-print-directory --directory $$subdir $@; done
 

--- a/src/main/go/app/Makefile
+++ b/src/main/go/app/Makefile
@@ -23,12 +23,12 @@ SIEVERANGE = 1000
 all: targets $(BINDIR)/app test
 
 $(BINDIR)/app : $(SRCDIR)/app.go
-	@$(BUILD) $@ $?
+	@$(BUILD) build $@ $?
 
 targets:
 	-@mkdir -p $(BINDIR)
 
-clean:
+clean scrub:
 	-@$(BUILD) $@
 	-@$(RM) -r $(BINDIR)
 
@@ -38,4 +38,4 @@ test:
 install:
 	-@$(BUILD) $@
 
-.PHONY: targets clean test install
+.PHONY: targets clean scrub test install

--- a/src/main/go/app/Makefile
+++ b/src/main/go/app/Makefile
@@ -13,40 +13,29 @@
 # limitations under the License.
 
 GO = go
-GCCGO = gccgo
-GCCGOFLAGS = -compiler $(GCCGO)
 
 SRCDIR = .
 BINDIR = bin
-
-LOG = .build.log
+BUILD  = ../build.sh
 
 SIEVERANGE = 1000
 
 all: targets $(BINDIR)/app test
 
 $(BINDIR)/app : $(SRCDIR)/app.go
-	@path=$$(which $(GCCGO)); \
-	if [ ! -z $${path} ]; \
-	then \
-		echo "$$(date) | gccgo | $(GO) build $(GCCGOFLAGS) -o $@ $?" >> $(LOG); \
-		$(GO) build $(GCCGOFLAGS) -o $@ $?; \
-	else \
-		echo "$$(date) | gccgo | $(GO) build -o $@ $?" >> $(LOG); \
-		$(GO) build -o $@ $?; \
-	fi
+	@$(BUILD) $@ $?
 
 targets:
 	-@mkdir -p $(BINDIR)
 
 clean:
+	-@$(BUILD) $@
 	-@$(RM) -r $(BINDIR)
-	-@$(RM) $(LOG)
 
 test:
 	@$(BINDIR)/app $(SIEVERANGE)
 
 install:
-	@$(GO) install
+	-@$(BUILD) $@
 
 .PHONY: targets clean test install

--- a/src/main/go/app/Makefile
+++ b/src/main/go/app/Makefile
@@ -13,23 +13,35 @@
 # limitations under the License.
 
 GO = go
-GOFLAGS = -v
+GCCGO = gccgo
+GCCGOFLAGS = -compiler $(GCCGO)
 
 SRCDIR = .
 BINDIR = bin
+
+LOG = .build.log
 
 SIEVERANGE = 1000
 
 all: targets $(BINDIR)/app test
 
 $(BINDIR)/app : $(SRCDIR)/app.go
-	@$(GO) build $(GOFLAGS) -o $@ $?
+	@path=$$(which $(GCCGO)); \
+	if [ ! -z $${path} ]; \
+	then \
+		echo "$$(date) | gccgo | $(GO) build $(GCCGOFLAGS) -o $@ $?" >> $(LOG); \
+		$(GO) build $(GCCGOFLAGS) -o $@ $?; \
+	else \
+		echo "$$(date) | gccgo | $(GO) build -o $@ $?" >> $(LOG); \
+		$(GO) build -o $@ $?; \
+	fi
 
 targets:
 	-@mkdir -p $(BINDIR)
 
 clean:
 	-@$(RM) -r $(BINDIR)
+	-@$(RM) $(LOG)
 
 test:
 	@$(BINDIR)/app $(SIEVERANGE)

--- a/src/main/go/app/Makefile
+++ b/src/main/go/app/Makefile
@@ -16,7 +16,7 @@ GO = go
 
 SRCDIR = .
 BINDIR = bin
-BUILD  = ../build.sh
+BUILD  = ../buildapp.sh
 
 SIEVERANGE = 1000
 
@@ -29,13 +29,13 @@ targets:
 	-@mkdir -p $(BINDIR)
 
 clean scrub:
-	-@$(BUILD) $@
-	-@$(RM) -r $(BINDIR)
+	@$(BUILD) $@
+	@$(RM) -r $(BINDIR)
 
 test:
 	@$(BINDIR)/app $(SIEVERANGE)
 
-install:
-	-@$(BUILD) $@
+install version:
+	@$(BUILD) $@
 
-.PHONY: targets clean scrub test install
+.PHONY: targets clean scrub test install version

--- a/src/main/go/app2/Makefile
+++ b/src/main/go/app2/Makefile
@@ -23,12 +23,12 @@ SIEVERANGE = 1000
 all: targets $(BINDIR)/app test
 
 $(BINDIR)/app : $(SRCDIR)/app.go
-	@$(BUILD) $@ $?
+	@$(BUILD) build $@ $?
 
 targets:
 	-@mkdir -p $(BINDIR)
 
-clean:
+clean scrub:
 	-@$(BUILD) $@
 	-@$(RM) -r $(BINDIR)
 
@@ -38,4 +38,4 @@ test:
 install:
 	-@$(BUILD) $@
 
-.PHONY: targets clean test install
+.PHONY: targets clean scrub test install

--- a/src/main/go/app2/Makefile
+++ b/src/main/go/app2/Makefile
@@ -13,40 +13,29 @@
 # limitations under the License.
 
 GO = go
-GCCGO = gccgo
-GCCGOFLAGS = -compiler $(GCCGO)
 
 SRCDIR = .
 BINDIR = bin
-
-LOG = .build.log
+BUILD  = ../build.sh
 
 SIEVERANGE = 1000
 
 all: targets $(BINDIR)/app test
 
 $(BINDIR)/app : $(SRCDIR)/app.go
-	@path=$$(which $(GCCGO)); \
-	if [ ! -z $${path} ]; \
-	then \
-		echo "$$(date) | gccgo | $(GO) build $(GCCGOFLAGS) -o $@ $?" >> $(LOG); \
-		$(GO) build $(GCCGOFLAGS) -o $@ $?; \
-	else \
-		echo "$$(date) | gccgo | $(GO) build -o $@ $?" >> $(LOG); \
-		$(GO) build -o $@ $?; \
-	fi
+	@$(BUILD) $@ $?
 
 targets:
 	-@mkdir -p $(BINDIR)
 
 clean:
+	-@$(BUILD) $@
 	-@$(RM) -r $(BINDIR)
-	-@$(RM) $(LOG)
 
 test:
 	@$(BINDIR)/app $(SIEVERANGE)
 
 install:
-	@$(GO) install
+	-@$(BUILD) $@
 
 .PHONY: targets clean test install

--- a/src/main/go/app2/Makefile
+++ b/src/main/go/app2/Makefile
@@ -13,24 +13,35 @@
 # limitations under the License.
 
 GO = go
-GOFLAGS = -compiler gccgo
-GOFLAGS =
+GCCGO = gccgo
+GCCGOFLAGS = -compiler $(GCCGO)
 
 SRCDIR = .
 BINDIR = bin
+
+LOG = .build.log
 
 SIEVERANGE = 1000
 
 all: targets $(BINDIR)/app test
 
 $(BINDIR)/app : $(SRCDIR)/app.go
-	@$(GO) build $(GOFLAGS) -o $@ $?
+	@path=$$(which $(GCCGO)); \
+	if [ ! -z $${path} ]; \
+	then \
+		echo "$$(date) | gccgo | $(GO) build $(GCCGOFLAGS) -o $@ $?" >> $(LOG); \
+		$(GO) build $(GCCGOFLAGS) -o $@ $?; \
+	else \
+		echo "$$(date) | gccgo | $(GO) build -o $@ $?" >> $(LOG); \
+		$(GO) build -o $@ $?; \
+	fi
 
 targets:
 	-@mkdir -p $(BINDIR)
 
 clean:
 	-@$(RM) -r $(BINDIR)
+	-@$(RM) $(LOG)
 
 test:
 	@$(BINDIR)/app $(SIEVERANGE)

--- a/src/main/go/app2/Makefile
+++ b/src/main/go/app2/Makefile
@@ -16,7 +16,7 @@ GO = go
 
 SRCDIR = .
 BINDIR = bin
-BUILD  = ../build.sh
+BUILD  = ../buildapp.sh
 
 SIEVERANGE = 1000
 
@@ -29,13 +29,13 @@ targets:
 	-@mkdir -p $(BINDIR)
 
 clean scrub:
-	-@$(BUILD) $@
-	-@$(RM) -r $(BINDIR)
+	@$(BUILD) $@
+	@$(RM) -r $(BINDIR)
 
 test:
 	@$(BINDIR)/app $(SIEVERANGE)
 
-install:
-	-@$(BUILD) $@
+install version:
+	@$(BUILD) $@
 
-.PHONY: targets clean scrub test install
+.PHONY: targets clean scrub test install version

--- a/src/main/go/app3/Makefile
+++ b/src/main/go/app3/Makefile
@@ -13,40 +13,29 @@
 # limitations under the License.
 
 GO = go
-GCCGO = gccgo
-GCCGOFLAGS = -compiler $(GCCGO)
 
 SRCDIR = .
 BINDIR = bin
-
-LOG = .build.log
+BUILD  = ../build.sh
 
 SIEVERANGE = 1000
 
 all: targets $(BINDIR)/app test
 
 $(BINDIR)/app : $(SRCDIR)/app.go $(SRCDIR)/sieve.go
-	@path=$$(which $(GCCGO)); \
-	if [ ! -z $${path} ]; \
-	then \
-		echo "$$(date) | gccgo | $(GO) build $(GCCGOFLAGS) -o $@ $?" >> $(LOG); \
-		$(GO) build $(GCCGOFLAGS) -o $@ $?; \
-	else \
-		echo "$$(date) | gccgo | $(GO) build -o $@ $?" >> $(LOG); \
-		$(GO) build -o $@ $?; \
-	fi
+	@$(BUILD) $@ $?
 
 targets:
 	-@mkdir -p $(BINDIR)
 
 clean:
+	-@$(BUILD) $@
 	-@$(RM) -r $(BINDIR)
-	-@$(RM) $(LOG)
 
 test:
 	@$(BINDIR)/app $(SIEVERANGE)
 
 install:
-	@$(GO) install
+	-@$(BUILD) $@
 
 .PHONY: targets clean test install

--- a/src/main/go/app3/Makefile
+++ b/src/main/go/app3/Makefile
@@ -13,25 +13,35 @@
 # limitations under the License.
 
 GO = go
-GOFLAGS = -compiler gccgo
-GOFLAGS =
-#CGO_LDFLAGS = -L/usr/local/lib -lcsieve
+GCCGO = gccgo
+GCCGOFLAGS = -compiler $(GCCGO)
 
 SRCDIR = .
 BINDIR = bin
+
+LOG = .build.log
 
 SIEVERANGE = 1000
 
 all: targets $(BINDIR)/app test
 
 $(BINDIR)/app : $(SRCDIR)/app.go $(SRCDIR)/sieve.go
-	@$(GO) build $(GOFLAGS) -o $@ $?
+	@path=$$(which $(GCCGO)); \
+	if [ ! -z $${path} ]; \
+	then \
+		echo "$$(date) | gccgo | $(GO) build $(GCCGOFLAGS) -o $@ $?" >> $(LOG); \
+		$(GO) build $(GCCGOFLAGS) -o $@ $?; \
+	else \
+		echo "$$(date) | gccgo | $(GO) build -o $@ $?" >> $(LOG); \
+		$(GO) build -o $@ $?; \
+	fi
 
 targets:
 	-@mkdir -p $(BINDIR)
 
 clean:
 	-@$(RM) -r $(BINDIR)
+	-@$(RM) $(LOG)
 
 test:
 	@$(BINDIR)/app $(SIEVERANGE)

--- a/src/main/go/app3/Makefile
+++ b/src/main/go/app3/Makefile
@@ -23,12 +23,12 @@ SIEVERANGE = 1000
 all: targets $(BINDIR)/app test
 
 $(BINDIR)/app : $(SRCDIR)/app.go $(SRCDIR)/sieve.go
-	@$(BUILD) $@ $?
+	@$(BUILD) build $@ $?
 
 targets:
 	-@mkdir -p $(BINDIR)
 
-clean:
+clean scrub:
 	-@$(BUILD) $@
 	-@$(RM) -r $(BINDIR)
 
@@ -38,4 +38,4 @@ test:
 install:
 	-@$(BUILD) $@
 
-.PHONY: targets clean test install
+.PHONY: targets clean scrub test install

--- a/src/main/go/app3/Makefile
+++ b/src/main/go/app3/Makefile
@@ -16,7 +16,7 @@ GO = go
 
 SRCDIR = .
 BINDIR = bin
-BUILD  = ../build.sh
+BUILD  = ../buildapp.sh
 
 SIEVERANGE = 1000
 
@@ -29,13 +29,13 @@ targets:
 	-@mkdir -p $(BINDIR)
 
 clean scrub:
-	-@$(BUILD) $@
-	-@$(RM) -r $(BINDIR)
+	@$(BUILD) $@
+	@$(RM) -r $(BINDIR)
 
 test:
 	@$(BINDIR)/app $(SIEVERANGE)
 
-install:
-	-@$(BUILD) $@
+install version:
+	@$(BUILD) $@
 
-.PHONY: targets clean scrub test install
+.PHONY: targets clean scrub test install version

--- a/src/main/go/build.sh
+++ b/src/main/go/build.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+
+# Copyright 2021 Shay Gordon
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GO=go
+GCCGO=gccgo
+GCCGOFLAGS="-compiler ${GCCGO}"
+LOG=.build.log
+
+rule=$1; shift
+
+case ${rule} in
+  clean)
+    rm -f ${LOG}
+    ${GO} ${rule}
+    exit $?
+    ;;
+  test)
+	  ${GO} test -v
+    exit $?
+    ;;
+  install)
+    ${GO} ${rule}
+    exit $?
+    ;;
+esac
+
+# build app or utility
+path=$(which ${GCCGO})
+if [ ! -z ${path} ]; then
+  echo "`date` | gccgo | ${GO} build ${GCCGOFLAGS} -o ${rule} $@" >> ${LOG}
+  ${GO} build ${GCCGOFLAGS} -o ${rule} $@
+else
+  if [ $# -gt 0 ]; then
+    echo "`date` | go    | ${GO} build -o ${rule} $@" >> ${LOG}
+    ${GO} build -o ${rule} $@
+  else
+    # assume target is a utility and check that it builds
+    echo "`date` | go    | ${GO} build ${rule}" >> ${LOG}
+    ${GO} build ${rule}
+  fi
+fi

--- a/src/main/go/buildapp.sh
+++ b/src/main/go/buildapp.sh
@@ -31,9 +31,13 @@ case ${cmd} in
   test)    args="-v ." ;;
   install) args=.      ;;
   clean)   args=.      ;;
+  version)
+    log "$(${GO} ${cmd})"
+    exit 0
+    ;;
   scrub)
     ${RM} ${LOG}
-    log ${cmd}
+    log "++ log scrubbed"
     exit 0
     ;;
   build)

--- a/src/main/go/buildutil.sh
+++ b/src/main/go/buildutil.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 log() {
-  printf "$(date) | app  | %-5s | ${1}\n" ${PKG} >> ${LOG}
+  printf "$(date) | util | %-5s | ${1}\n" ${PKG} >> ${LOG}
 }
 
 GO=go
@@ -41,9 +41,7 @@ case ${cmd} in
     if [ ! -z ${path} ]; then
       args=${GCCGOFLAGS}
     fi
-    app=$1
-    shift
-    args="${args}-o ${app} $@"
+    args="${args}."
     ;;
   *)
     echo unknown command: ${cmd}
@@ -51,5 +49,6 @@ case ${cmd} in
     ;;
 esac
 log "${GO} ${cmd} ${args}"
+echo ${GO} ${cmd} ${args}
 ${GO} ${cmd} ${args}
 exit $?

--- a/src/main/go/buildutil.sh
+++ b/src/main/go/buildutil.sh
@@ -31,9 +31,13 @@ case ${cmd} in
   test)    args="-v ." ;;
   install) args=.      ;;
   clean)   args=.      ;;
+  version)
+    log "$(${GO} ${cmd})"
+    exit 0
+    ;;
   scrub)
     ${RM} ${LOG}
-    log ${cmd}
+    log "++ log scrubbed"
     exit 0
     ;;
   build)

--- a/src/main/go/sieve/Makefile
+++ b/src/main/go/sieve/Makefile
@@ -20,7 +20,7 @@ all: build
 build: $(SRCDIR)/sieve.go
 	@$(BUILD) $@ $?
 
-clean scrub test install:
+clean scrub test install version:
 	@$(BUILD) $@
 
-.PHONY: clean scrub test install
+.PHONY: clean scrub test install version

--- a/src/main/go/sieve/Makefile
+++ b/src/main/go/sieve/Makefile
@@ -13,16 +13,28 @@
 # limitations under the License.
 
 GO = go
-GOFLAGS = -compiler gccgo
-GOFLAGS =
+GCCGO = gccgo
+GCCGOFLAGS = -compiler $(GCCGO)
+
+SRCDIR = .
+LOG = .build.log
 
 all: build
 
-build:
-	@$(GO) build $(GOFLAGS) .
+build: $(SRCDIR)/sieve.go
+	@path=$$(which $(GCCGO)); \
+	if [ ! -z $${path} ]; \
+	then \
+		echo "$$(date) | gccgo | $(GO) build $(GCCGOFLAGS) $?" >> $(LOG); \
+		$(GO) build $(GCCGOFLAGS) $?; \
+	else \
+		echo "$$(date) | gccgo | $(GO) build $?" >> $(LOG); \
+		$(GO) build $?; \
+	fi
 
 clean:
 	@$(GO) clean
+	@$(RM) $(LOG)
 
 test:
 	@$(GO) test -v

--- a/src/main/go/sieve/Makefile
+++ b/src/main/go/sieve/Makefile
@@ -12,23 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GO = go
-
 SRCDIR = .
-BUILD  = ../build.sh
+BUILD  = ../buildutil.sh
 
 all: build
 
 build: $(SRCDIR)/sieve.go
-	@$(BUILD) $?
+	@$(BUILD) $@ $?
 
-clean:
+clean scrub test install:
 	@$(BUILD) $@
 
-test:
-	@$(BUILD) $@
-
-install:
-	-@$(BUILD) $@
-
-.PHONY: clean test install
+.PHONY: clean scrub test install

--- a/src/main/go/sieve/Makefile
+++ b/src/main/go/sieve/Makefile
@@ -13,33 +13,22 @@
 # limitations under the License.
 
 GO = go
-GCCGO = gccgo
-GCCGOFLAGS = -compiler $(GCCGO)
 
 SRCDIR = .
-LOG = .build.log
+BUILD  = ../build.sh
 
 all: build
 
 build: $(SRCDIR)/sieve.go
-	@path=$$(which $(GCCGO)); \
-	if [ ! -z $${path} ]; \
-	then \
-		echo "$$(date) | gccgo | $(GO) build $(GCCGOFLAGS) $?" >> $(LOG); \
-		$(GO) build $(GCCGOFLAGS) $?; \
-	else \
-		echo "$$(date) | gccgo | $(GO) build $?" >> $(LOG); \
-		$(GO) build $?; \
-	fi
+	@$(BUILD) $?
 
 clean:
-	@$(GO) clean
-	@$(RM) $(LOG)
+	@$(BUILD) $@
 
 test:
-	@$(GO) test -v
+	@$(BUILD) $@
 
 install:
-	@$(GO) install
+	-@$(BUILD) $@
 
 .PHONY: clean test install


### PR DESCRIPTION
Add ability to use Go's `gccgo` compiler if it's available and write all `go` commands executed to a local hidden `.golog` file. Also:
- install Ubuntu `gccgo` instead of `gccgo-go` package
- add build script for Go apps
- add `prime bounce` command to stop, rebuild and restart docker containers