### PR TITLE
1.2.0 patches

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,7 +37,7 @@ test-classes/
 __pycache__/
 
 # Go makefile-generated files
-.build.log
+.golog
 
 # END include .gitignore -----------------------------------------------------
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@ test-classes/
 __pycache__/
 
 # Go makefile-generated files
-.build.log
+.golog

--- a/prime
+++ b/prime
@@ -104,9 +104,13 @@ do
 
     alpine|fedora|ubuntu)
       if [ ! -z $@ ]; then
-        # alpine: bash not installed, use ash instead
         arg=$@
-        if [ ${cmd} == "alpine" ] && [ ${arg} == "bash" ]; then arg=ash; fi
+        # if shell not installed, use default shell for distro
+        case ${cmd} in
+          alpine) if [ ${arg} == "bash" ]; then arg=ash;  fi ;;
+          fedora) if [ ${arg} == "ash"  ]; then arg=sh;   fi ;;
+          ubuntu) if [ ${arg} == "ash"  ]; then arg=bash; fi ;;
+        esac
         case ${arg} in
           clean|all) docker compose exec ${cmd} ./${self} ${arg} ;;
           *)         docker compose exec ${cmd} ${arg}           ;;


### PR DESCRIPTION
In `prime` script, if shell is not known, use default container shell to attach to a container.